### PR TITLE
Bug Fix

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -176,7 +176,13 @@ function Chat({
             itemVisiblePercentThreshold: 50,
           }}
           inverted
-          onEndReached={onEndReached}
+          // Prevent `onEndReached` from triggering every time the layout changes
+          onEndReached={({ distanceFromEnd }) => {
+            if (distanceFromEnd > 0 && distanceFromEnd < 50) {
+              // Adjust distanceFromEnd threshold as needed
+              onEndReached && onEndReached();
+            }
+          }}
           onEndReachedThreshold={0.1}
         />
         {customFooter ? (


### PR DESCRIPTION
Issue Description
In the chat application, the onEndReached event is triggered unexpectedly when opening or closing the keyboard on mobile devices. This results in an alert stating, "You have reached the end of the page," even when there are only a few chat messages (e.g., only two messages present in the chat).

Observed Behavior:
Triggering Condition: The alert is displayed regardless of the actual scroll position in the FlatList.
Expected Behavior: The alert should only trigger when the user scrolls to the end of the chat messages, not when interacting with the keyboard.
Steps to Reproduce:
Open the chat application on a mobile device.
Observe the chat messages displayed.
Open the keyboard by tapping on the message input field.
Close the keyboard and observe the alert triggering incorrectly.
Note that this occurs even when there are only two messages in the chat.

Impact:
This issue affects user experience by misleading users into thinking there are more messages to load when there are not. It may cause confusion and frustration, especially in scenarios with minimal chat history.